### PR TITLE
Generator update

### DIFF
--- a/flint-sys/src/lib.rs
+++ b/flint-sys/src/lib.rs
@@ -1032,11 +1032,19 @@ extern "C" {
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c.fmpz_mod_poly_realloc) for this function.
     #[link_name = "fmpz_mod_poly_realloc"]
-    pub fn fmpz_mod_poly_realloc(poly: *const fmpz_mod_poly, alloc: slong, ctx: *const fmpz_mod_ctx);
+    pub fn fmpz_mod_poly_realloc(
+        poly: *const fmpz_mod_poly,
+        alloc: slong,
+        ctx: *const fmpz_mod_ctx,
+    );
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c.fmpz_mod_poly_fit_length) for this function.
     #[link_name = "fmpz_mod_poly_fit_length"]
-    pub fn fmpz_mod_poly_fit_length(poly: *const fmpz_mod_poly, len: slong, ctx: *const fmpz_mod_ctx);
+    pub fn fmpz_mod_poly_fit_length(
+        poly: *const fmpz_mod_poly,
+        len: slong,
+        ctx: *const fmpz_mod_ctx,
+    );
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c._fmpz_mod_poly_normalise) for this function.
     #[link_name = "_fmpz_mod_poly_normalise"]
@@ -1224,7 +1232,11 @@ extern "C" {
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c.fmpz_mod_poly_set_fmpz) for this function.
     #[link_name = "fmpz_mod_poly_set_fmpz"]
-    pub fn fmpz_mod_poly_set_fmpz(f: *const fmpz_mod_poly, c: *const fmpz, ctx: *const fmpz_mod_ctx);
+    pub fn fmpz_mod_poly_set_fmpz(
+        f: *const fmpz_mod_poly,
+        c: *const fmpz,
+        ctx: *const fmpz_mod_ctx,
+    );
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c.fmpz_mod_poly_set_fmpz_poly) for this function.
     #[link_name = "fmpz_mod_poly_set_fmpz_poly"]

--- a/flint-sys/src/lib.rs
+++ b/flint-sys/src/lib.rs
@@ -104,16 +104,17 @@ extern "C" {
     pub fn fmpz_mod_ctx_init(ctx: *const fmpz_mod_ctx, n: *const fmpz);
     pub fn fmpz_mod_ctx_clear(ctx: *const fmpz_mod_ctx);
 
-    /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz.html#c.fmpz_init) for this function.
-    #[link_name = "__fmpz_init"]
-    pub fn fmpz_init(f: *mut fmpz);
+    /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz.html#c._fmpz_promote_val) for this function.
+    #[link_name = "_fmpz_promote_val"]
+    pub fn _fmpz_promote_val(f: *mut fmpz) -> *mut gmp::mpz_t;
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz.html#c._fmpz_demote_val) for this function.
     #[link_name = "_fmpz_demote_val"]
     pub fn _fmpz_demote_val(f: *mut fmpz);
-    /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz.html#c._fmpz_promote_val) for this function.
-    #[link_name = "_fmpz_promote_val"]
-    pub fn _fmpz_promote_val(f: *mut fmpz) -> *mut gmp::mpz_t;
+
+    /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz.html#c.fmpz_init) for this function.
+    #[link_name = "__fmpz_init"]
+    pub fn fmpz_init(f: *mut fmpz);
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz.html#c.fmpz_init2) for this function.
     #[link_name = "fmpz_init2"]
@@ -1168,10 +1169,6 @@ extern "C" {
         ctx: *const fmpz_mod_ctx,
     );
 
-    // /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c.fmpz_mod_poly_modulus) for this function.
-    //#[link_name = "fmpz_mod_poly_modulus"]
-    //pub fn fmpz_mod_poly_modulus(poly: *const fmpz_mod_poly) -> *mut fmpz;
-
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c.fmpz_mod_poly_degree) for this function.
     #[link_name = "fmpz_mod_poly_degree"]
     pub fn fmpz_mod_poly_degree(poly: *const fmpz_mod_poly, ctx: *const fmpz_mod_ctx) -> slong;
@@ -1330,7 +1327,13 @@ extern "C" {
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c._fmpz_mod_poly_shift_left) for this function.
     #[link_name = "_fmpz_mod_poly_shift_left"]
-    pub fn _fmpz_mod_poly_shift_left(res: *mut fmpz, poly: *const fmpz, len: slong, n: slong);
+    pub fn _fmpz_mod_poly_shift_left(
+        res: *mut fmpz,
+        poly: *const fmpz,
+        len: slong,
+        n: slong,
+        ctx: *const fmpz_mod_ctx,
+    );
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c.fmpz_mod_poly_shift_left) for this function.
     #[link_name = "fmpz_mod_poly_shift_left"]
@@ -1343,7 +1346,13 @@ extern "C" {
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c._fmpz_mod_poly_shift_right) for this function.
     #[link_name = "_fmpz_mod_poly_shift_right"]
-    pub fn _fmpz_mod_poly_shift_right(res: *mut fmpz, poly: *const fmpz, len: slong, n: slong);
+    pub fn _fmpz_mod_poly_shift_right(
+        res: *mut fmpz,
+        poly: *const fmpz,
+        len: slong,
+        n: slong,
+        ctx: *const fmpz_mod_ctx,
+    );
 
     /// See the [FLINT Documentation](http://flintlib.org/doc/fmpz_mod_poly.html#c.fmpz_mod_poly_shift_right) for this function.
     #[link_name = "fmpz_mod_poly_shift_right"]


### PR DESCRIPTION
Update the generator to work with the current documentation and re-run it. I added a `cargo fmt` commit first, to make it easier to compare the before/after versions.

The only meaningful changes are, that a `ctx` have been added to `_fmpz_mod_poly_shift_left` and `_fmpz_mod_poly_shift_right`.