### PR TITLE
Remove `mult_same_as_gmp` test for now

### DIFF
--- a/flint-sys/src/lib.rs
+++ b/flint-sys/src/lib.rs
@@ -109,9 +109,14 @@ mod tests {
             debug_assert!(
                 fmpz_mod_poly::fmpz_mod_poly_print_pretty(&mut f, x.as_ptr(), &mut ctx) > 0
             );
+            fmpz_mod_poly::fmpz_mod_poly_clear(&mut f, &mut ctx);
+            fmpz_mod::fmpz_mod_ctx_clear(&mut ctx);
+            fmpz::fmpz_clear(&mut p);
+
         }
     }
 
+    /*
     mod random {
         use crate::*;
         use gmp_mpfr_sys::gmp;
@@ -125,24 +130,31 @@ mod tests {
                 gmp::mpz_init(g_v.as_mut_ptr());
                 let mut g_v = g_v.assume_init();
                 gmp::mpz_set_ui(&mut g_v, v);
+
                 let mut g_u = MaybeUninit::uninit();
                 gmp::mpz_init(g_u.as_mut_ptr());
                 let mut g_u = g_u.assume_init();
                 gmp::mpz_set_ui(&mut g_u, u);
+
                 let mut f_u = fmpz::fmpz::default();
                 fmpz::fmpz_init(&mut f_u);
                 fmpz::fmpz_set_ui(&mut f_u, u);
+
                 let mut f_v = fmpz::fmpz::default();
                 fmpz::fmpz_init(&mut f_v);
                 fmpz::fmpz_set_ui(&mut f_v, v);
+
                 gmp::mpz_mul(&mut g_v, &g_v, &g_u);
                 fmpz::fmpz_mul(&mut f_v, &f_v, &f_u);
                 let f_as_g = fmpz::_fmpz_promote_val(&mut f_v);
                 let eq = gmp::mpz_cmp(flint_to_gmp::mpz_srcptr(f_as_g), &g_v) == 0;
+
                 gmp::mpz_clear(&mut g_v);
                 gmp::mpz_clear(&mut g_u);
                 gmp::mpz_clear(flint_to_gmp::mpz_ptr(f_as_g));
+                fmpz::_fmpz_demote_val(&mut f_v);
                 fmpz::fmpz_clear(&mut f_u);
+                fmpz::fmpz_clear(&mut f_v);
                 eq
             }
         }
@@ -167,5 +179,5 @@ mod tests {
                 unsafe { &mut std::mem::transmute(*p) }
             }
         }
-    }
+    }*/
 }


### PR DESCRIPTION
[Issue 9](https://github.com/alex-ozdemir/flint-rs/issues/9) shows the test is failing due to a double free. Valgrind shows there is an issue with the use of `_fmpz_promote_val`. I tinkered with using `_fmpz_demote_val` and added missing `clear`s but haven't found a fix. I commented out the test for now.

@alex-ozdemir Feel free to look into this test if you want. We can consider adding `gmp-mpfr-sys` as a dependency again to avoid the transmutes as well.

```
failures:
    tests::random::mult_same_as_gmp

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.29s

==78696== 
==78696== HEAP SUMMARY:
==78696==     in use at exit: 167,728 bytes in 4,071 blocks
==78696==   total heap usage: 4,958 allocs, 916 frees, 278,371 bytes allocated
==78696== 
==78696== Thread 1:
==78696== 167,424 (32,768 direct, 134,656 indirect) bytes in 1 blocks are definitely lost in loss record 9 of 9
==78696==    at 0x48416C6: realloc (vg_replace_malloc.c:1437)
==78696==    by 0x4915D42: flint_realloc (memory_manager.c:118)
==78696==    by 0x493CDD4: _fmpz_new_mpz (fmpz.c:115)
==78696==    by 0x493D1A7: _fmpz_promote_val (fmpz.c:225)
==78696==    by 0x15FD1B: _ZN9flint_sys5tests6random16mult_same_as_gmp16mult_same_as_gmp17h79fc3e26b7628637E.llvm.11491476516669631521 (in /home/wyoumans/repos/flint-rs/target/release/deps/flint_sys-04b1d0818299e16d)
==78696==    by 0x15E9CA: quickcheck::tester::quickcheck (in /home/wyoumans/repos/flint-rs/target/release/deps/flint_sys-04b1d0818299e16d)
==78696==    by 0x214472: test::__rust_begin_short_backtrace (function.rs:227)
==78696==    by 0x212EF7: test::run_test::run_test_inner::{{closure}} (boxed.rs:1691)
==78696==    by 0x1DF0DD: std::sys_common::backtrace::__rust_begin_short_backtrace (lib.rs:527)
==78696==    by 0x1E3ED7: core::ops::function::FnOnce::call_once{{vtable.shim}} (mod.rs:483)
==78696==    by 0x2BCF32: std::sys::unix::thread::Thread::new::thread_start (boxed.rs:1691)
==78696==    by 0x5379608: start_thread (pthread_create.c:477)
==78696== 
==78696== LEAK SUMMARY:
==78696==    definitely lost: 32,768 bytes in 1 blocks
==78696==    indirectly lost: 134,656 bytes in 4,065 blocks
==78696==      possibly lost: 0 bytes in 0 blocks
==78696==    still reachable: 304 bytes in 5 blocks
==78696==         suppressed: 0 bytes in 0 blocks
```