### PR TITLE
Add make -j to speed up build time

### DIFF
--- a/flint-sys/Cargo.toml
+++ b/flint-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flint-sys"
-version = "0.7.0"
+version = "0.7.1"
 links = "flint"
 authors = ["Alex Ozdemir <aozdemir@hmc.edu>"]
 edition = "2018"

--- a/flint-sys/build.rs
+++ b/flint-sys/build.rs
@@ -128,6 +128,7 @@ struct Environment {
     include_dir: PathBuf,
     build_dir: PathBuf,
     cache_dir: Option<PathBuf>,
+    jobs: OsString
 }
 
 fn main() {
@@ -180,6 +181,7 @@ fn main() {
         include_dir: out_dir.join("include"),
         build_dir: out_dir.join("build"),
         cache_dir,
+        jobs: cargo_env("NUM_JOBS"),
     };
        
     // make sure we have target directories
@@ -416,15 +418,17 @@ fn configure(build_dir: &Path, conf_line: &OsStr) {
     execute(conf);
 }
 
-fn make_and_check(_env: &Environment, build_dir: &Path) {
+fn make_and_check(env: &Environment, build_dir: &Path) {
     let mut make = Command::new("make");
-    make.current_dir(build_dir);
+    make.current_dir(build_dir).arg("-j").arg(&env.jobs); 
     execute(make);
 
     if !cfg!(feature = "disable-make-check") {
         let mut make_check = Command::new("make");
         make_check
             .current_dir(build_dir)
+            .arg("-j")
+            .arg(&env.jobs)
             .arg("check");
         execute(make_check);
     }

--- a/flint-sys/src/deps.rs
+++ b/flint-sys/src/deps.rs
@@ -1,7 +1,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 
-//! We avoid a gmp-mpfr-sys dependency by defining the GMP and MPFR types used by FLINT.
 
 use libc::{c_int, c_long, c_uint, c_ulong, c_void, size_t};
 


### PR DESCRIPTION
Build flint with `make -j` with the number of jobs given by cargos `NUM_JOBS` environment variable. Build time goes from ~9 minutes to ~4 minutes on my laptop.