### PR TITLE
Mark `fmpz_sqrtrem` second parameter as mutable

### DIFF
--- a/flint-sys/src/fmpz.rs
+++ b/flint-sys/src/fmpz.rs
@@ -207,7 +207,7 @@ extern "C" {
     pub fn fmpz_is_square(f: *const fmpz) -> c_int;
     pub fn fmpz_root(r: *mut fmpz, f: *const fmpz, n: mp_limb_signed_t);
     pub fn fmpz_is_perfect_power(root: *mut fmpz, f: *const fmpz) -> c_int;
-    pub fn fmpz_sqrtrem(f: *mut fmpz, r: *const fmpz, g: *const fmpz);
+    pub fn fmpz_sqrtrem(f: *mut fmpz, r: *mut fmpz, g: *const fmpz);
     pub fn fmpz_fdiv_ui(g: *const fmpz, h: mp_limb_t) -> mp_limb_t;
     pub fn fmpz_mod_ui(f: *mut fmpz, g: *const fmpz, h: mp_limb_t) -> mp_limb_t;
     pub fn fmpz_mod(f: *mut fmpz, g: *const fmpz, h: *const fmpz);


### PR DESCRIPTION
The remainder of the modulo operation is written into `r`. Therefore, it should require `mut`.

Documentation (https://www.flintlib.org/doc/fmpz.html?highlight=fmpz_sqrtrem#c.fmpz_sqrtrem): 
> [...] and sets *r* to the remainder [...]